### PR TITLE
Fix Moment 8 and Moment 9 Masking

### DIFF
--- a/bettermoments/methods.py
+++ b/bettermoments/methods.py
@@ -189,6 +189,8 @@ def collapse_eighth(velax, data, rms):
             The peak value, ``M8``, and the associated uncertainty, ``dM8``.
     """
     M8 = np.max(data, axis=0)
+    loc = np.where(np.max(data, axis=0)==0)
+    M8[loc] = np.nan
     dM8 = rms * np.ones(M8.shape)
     return M8, dM8
 
@@ -210,6 +212,8 @@ def collapse_ninth(velax, data, rms):
             uncertainty, ``dM9``.
     """
     M9 = velax[np.argmax(data, axis=0)]
+    loc = np.where(np.max(data, axis=0)==0)
+    M9[loc] = np.nan
     dM9 = 0.5 * abs(np.diff(velax).mean()) * np.ones(M9.shape)
     return M9, dM9
 


### PR DESCRIPTION
Remove bug where masked portions of Moment 8 and Moment 9 defaulted to 0 (for Moment 8) or the maximum velocity (for Moment 9)